### PR TITLE
Add dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'simplecov', :require => false, :group => :test
-gem 'mocha', :require => false, :group => :test
-gem 'rest-client'
-gem 'hashie'
-gem 'rake'
-gem 'json'
+gemspec

--- a/moodle.gemspec
+++ b/moodle.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |spec|
   spec.license     = 'MIT'
   
   spec.add_runtime_dependency 'rest-client', '~> 1.8'
-  spec.add_runtime_dependency 'sanitize', '~> 1.4'
   spec.add_runtime_dependency 'hashie', '~> 3.4'
+  spec.add_runtime_dependency 'json', '~> 1.8'
+
+  spec.add_development_dependency 'rake', '~> 11.1'
+  spec.add_development_dependency 'simplecov', '~> 0.11'
+  spec.add_development_dependency 'mocha', '~> 1.1'
 end

--- a/moodle.gemspec
+++ b/moodle.gemspec
@@ -10,4 +10,8 @@ Gem::Specification.new do |spec|
   spec.homepage    =
     'http://robertboloc.github.com/moodle'
   spec.license     = 'MIT'
+  
+  spec.add_runtime_dependency 'rest-client', '~> 1.8'
+  spec.add_runtime_dependency 'sanitize', '~> 1.4'
+  spec.add_runtime_dependency 'hashie', '~> 3.4'
 end


### PR DESCRIPTION
Currently the gemspec does not contain the dependencies. This leads to weird errors like `LoadError: cannot load such file -- rest-client` after you install the gem. I may have missed dependencies as i just added what i needed in order to install this gem, but i already have quite a lot of gems on my system.
